### PR TITLE
Fix workflow consistency for PR merging

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,9 +69,9 @@ flutter analyze
 - Recent commits: Foundation → Models → Package upgrades
 
 ## Agent Mode Workflow
-When working in agent mode you MUST create a new branch for the work from main BEFORE starting on any change session, where a change session is a set of changes and interactions designed to effect a feature or similar. When it is indicated that we're done, e.g. 'lets button this up', or 'we're done' or similar, prepare a commit with a succinct message, commit the change to the working branch, then make a PR to merge it to main, once it has been merged to main, offer to remove the old branch
+When working in agent mode you MUST create a new branch for the work from main BEFORE starting on any change session, where a change session is a set of changes and interactions designed to effect a feature or similar. When it is indicated that we're done, e.g. 'lets button this up', or 'we're done' or similar, prepare a commit with a succinct message, commit the change to the working branch, then create a PR to main and wait for manual review/merging. Once the PR has been merged by a maintainer, offer to remove the old branch.
 
-**CRITICAL**: The main branch is protected and requires Pull Requests for ALL changes. Direct pushes to main are NEVER allowed. Force pushes are prohibited. Always work on feature branches and create PRs for review and merging.
+**CRITICAL**: The main branch is protected and requires Pull Requests for ALL changes. Direct pushes to main are NEVER allowed. Force pushes are prohibited. Always work on feature branches and create PRs for review and merging. Agents CANNOT merge their own PRs.
 
 ## Coding Conventions
 - Use Dart/Flutter best practices with const constructors where possible


### PR DESCRIPTION
Clarifies that agents create PRs but wait for manual merging, resolving inconsistency in workflow instructions.